### PR TITLE
Remove compression dependency

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -9,8 +9,8 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
-    flavor: m1.mac
+    image: package-ci/mac:stable
+    flavor: b1.large
 ---
 pack:
   name: Pack

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This script allows you to inspect this information graphically in the Editor UI,
 Disclaimer
 ==========
 
-This package gets the information it can from the BuildReport Scripting API (https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildReport.html), but some information in the BuildReport object is not yet exposed through public APIs.  
+This package is provided as-is, with no support from Unity Technologies. We plan to add a built-in and supported UI for the BuildReport feature in a future version of Unity, but until then, this package serves as a demonstration on how you can access the BuildReport information today.
+
+In particular, this package gets the information it can from the BuildReport Scripting API (https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildReport.html).  
 
 
 Usage

--- a/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
+++ b/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
@@ -384,7 +384,7 @@ namespace Unity.BuildReportInspector
             {
                 EditorGUILayout.HelpBox("To get more accurate report data, please provide an .ipa file generated from a " +
                                         "matching Unity build using the dialog below.", MessageType.Warning);
-                if (!GUILayout.Button("Select an iOS .ipa bundle"))
+                if (!GUILayout.Button("Select an .ipa bundle"))
                 {
                     return;
                 }

--- a/com.unity.build-report-inspector/Editor/Mobile/AndroidUtilities.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/AndroidUtilities.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.Android;
 using UnityEngine;
+using Unity.BuildReportInspector.Mobile.ZipUtility;
 
 namespace Unity.BuildReportInspector.Mobile
 {
@@ -98,7 +98,7 @@ namespace Unity.BuildReportInspector.Mobile
         public MobileArchInfo[] GetArchitectureInfo(string applicationPath)
         {
             MobileArchInfo[] architectures;
-            using (var archive = ZipFile.OpenRead(applicationPath))
+            using (var archive = new ZipBundle(applicationPath))
             {
                 var archList = new List<MobileArchInfo>();
                 foreach (var file in archive.Entries)
@@ -140,7 +140,7 @@ namespace Unity.BuildReportInspector.Mobile
 
         private static ApplicationType GetApplicationType(string applicationPath)
         {
-            using (var archive = ZipFile.OpenRead(applicationPath))
+            using (var archive = new ZipBundle(applicationPath))
             {
                 if (archive.Entries.Any(x => x.FullName == "BundleConfig.pb"))
                 {

--- a/com.unity.build-report-inspector/Editor/Mobile/AppleUtilities.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/AppleUtilities.cs
@@ -14,6 +14,7 @@ namespace Unity.BuildReportInspector.Mobile
         private const string k_UnityFrameworkRelativePath = "Frameworks/UnityFramework.framework/UnityFramework";
         private const string k_Size = "/usr/bin/size";
         private const string k_File = "/usr/bin/file";
+        private const string k_Unzip = "/usr/bin/unzip";
 
         public MobileArchInfo[] GetArchitectureInfo(string applicationPath)
         {
@@ -31,7 +32,7 @@ namespace Unity.BuildReportInspector.Mobile
                         throw new Exception("Failed to locate UnityFramework file in the build.");
                     }
 
-                    Utilities.UnzipFile(applicationPath, unityFramework.FullName, frameworkFile);
+                    UnzipFile(applicationPath, unityFramework.FullName, frameworkFile);
                     appSizeNoFramework = new FileInfo(applicationPath).Length - unityFramework.CompressedSize;
                 }
 
@@ -106,6 +107,43 @@ namespace Unity.BuildReportInspector.Mobile
             finally
             {
                 Directory.Delete(temporaryFolder, true);
+            }
+        }
+
+        /// <summary>
+        /// Unzip a file from a zip archive (macOS only).
+        /// </summary>
+        internal static void UnzipFile(string archivePath, string fileName, string destination)
+        {
+            using (var p = new Process())
+            {
+                p.StartInfo.FileName = k_Unzip;
+                p.StartInfo.Arguments = $"-p \"{archivePath}\" \"{fileName}\"";
+                p.StartInfo.UseShellExecute = false;
+                p.StartInfo.CreateNoWindow = true;
+                p.StartInfo.RedirectStandardOutput = true;
+                p.StartInfo.RedirectStandardError = true;
+                p.Start();
+                var baseStream = p.StandardOutput.BaseStream as FileStream;
+                byte[] fileBytes;
+                using (var memoryStream = new MemoryStream())
+                {
+                    var buffer = new byte[65536];
+                    int lastRead;
+                    do
+                    {
+                        lastRead = baseStream.Read(buffer, 0, buffer.Length);
+                        memoryStream.Write(buffer, 0, lastRead);
+                    } while (lastRead > 0);
+
+                    fileBytes = memoryStream.ToArray();
+                }
+
+                using (var fileStream = new FileStream(destination, FileMode.Create))
+                {
+                    fileStream.Write(fileBytes, 0, fileBytes.Length);
+                }
+                p.WaitForExit();
             }
         }
     }

--- a/com.unity.build-report-inspector/Editor/Mobile/AppleUtilities.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/AppleUtilities.cs
@@ -1,10 +1,11 @@
 using System;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using Debug = UnityEngine.Debug;
 using System.Collections.Generic;
+using System.Diagnostics;
 using UnityEditor;
+using Unity.BuildReportInspector.Mobile.ZipUtility;
 
 namespace Unity.BuildReportInspector.Mobile
 {
@@ -21,7 +22,7 @@ namespace Unity.BuildReportInspector.Mobile
             {
                 var frameworkFile = Path.Combine(temporaryFolder, "UnityFramework");
                 long appSizeNoFramework;
-                using (var archive = ZipFile.OpenRead(applicationPath))
+                using (var archive = new ZipBundle(applicationPath))
                 {
                     var unityFramework = archive.Entries.FirstOrDefault(x =>
                         x.FullName.EndsWith(k_UnityFrameworkRelativePath, StringComparison.InvariantCulture));
@@ -30,8 +31,8 @@ namespace Unity.BuildReportInspector.Mobile
                         throw new Exception("Failed to locate UnityFramework file in the build.");
                     }
 
-                    unityFramework.ExtractToFile(frameworkFile);
-                    appSizeNoFramework = new FileInfo(applicationPath).Length - unityFramework.CompressedLength;
+                    Utilities.UnzipFile(applicationPath, unityFramework.FullName, frameworkFile);
+                    appSizeNoFramework = new FileInfo(applicationPath).Length - unityFramework.CompressedSize;
                 }
 
                 var foundArchitectures = new List<string>();

--- a/com.unity.build-report-inspector/Editor/Mobile/MobileAppendix.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/MobileAppendix.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using UnityEngine;
+using Unity.BuildReportInspector.Mobile.ZipUtility;
 
 namespace Unity.BuildReportInspector.Mobile
 {
@@ -66,19 +66,19 @@ namespace Unity.BuildReportInspector.Mobile
             BuildSize = new FileInfo(applicationPath).Length;
 
             // Get the list of files inside of the app bundle from the zip header
-            using (var archive = ZipFile.OpenRead(applicationPath))
+            using (var archive = new ZipBundle(applicationPath))
             {
                 var files = new List<MobileFile>();
                 foreach (var entry in archive.Entries)
                 {
                     // Skip iOS/tvOS directory meta files
-                    if (entry.Length == 0)
+                    if (entry.CompressedSize == 0)
                         continue;
 
                     files.Add(new MobileFile(
                         entry.FullName,
-                        entry.CompressedLength,
-                        entry.Length));
+                        entry.CompressedSize,
+                        entry.UncompressedSize));
                 }
                 Files = files.ToArray();
             }
@@ -94,7 +94,7 @@ namespace Unity.BuildReportInspector.Mobile
         {
             try
             {
-                using (var archive = ZipFile.OpenRead(buildPath))
+                using (var archive = new ZipBundle(buildPath))
                 {
                     return archive.Entries.Any(x =>
                         x.FullName == "AndroidManifest.xml" ||

--- a/com.unity.build-report-inspector/Editor/Mobile/MobileHelper.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/MobileHelper.cs
@@ -38,7 +38,7 @@ namespace Unity.BuildReportInspector.Mobile
                     var guidFile = archive.Entries.FirstOrDefault(x => x.Name == "UnityBuildGuid.txt");
                     if (guidFile == null)
                     {
-                        Debug.LogError("The provided application was built before BuildReportInspector package was added to the project.");
+                        Debug.LogError("The signature of the opened build report doesn't match the provided application.");
                         return;
                     }
 

--- a/com.unity.build-report-inspector/Editor/Mobile/MobileHelper.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/MobileHelper.cs
@@ -43,7 +43,7 @@ namespace Unity.BuildReportInspector.Mobile
                     }
 
                     var guidUnzipped = Path.Combine(temporaryFolder, "UnityBuildGuid.txt");
-                    Utilities.UnzipFile(applicationPath, guidFile.FullName, guidUnzipped);
+                    AppleUtilities.UnzipFile(applicationPath, guidFile.FullName, guidUnzipped);
                     using (var reader = new StreamReader(guidUnzipped))
                     {
                         var applicationGuid = reader.ReadToEnd();

--- a/com.unity.build-report-inspector/Editor/Mobile/MobileHelper.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/MobileHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using UnityEngine;
+using Unity.BuildReportInspector.Mobile.ZipUtility;
 
 namespace Unity.BuildReportInspector.Mobile
 {
@@ -28,10 +29,11 @@ namespace Unity.BuildReportInspector.Mobile
 
         internal static void GenerateAppleAppendix(string applicationPath, string guid)
         {
+            var temporaryFolder = Utilities.GetTemporaryFolder();
             try
             {
                 MobileHelper.RegisterPlatformUtilities(new AppleUtilities());
-                using (var archive = ZipFile.OpenRead(applicationPath))
+                using (var archive = new ZipBundle(applicationPath))
                 {
                     var guidFile = archive.Entries.FirstOrDefault(x => x.Name == "UnityBuildGuid.txt");
                     if (guidFile == null)
@@ -40,7 +42,9 @@ namespace Unity.BuildReportInspector.Mobile
                         return;
                     }
 
-                    using (var reader = new StreamReader(guidFile.Open()))
+                    var guidUnzipped = Path.Combine(temporaryFolder, "UnityBuildGuid.txt");
+                    Utilities.UnzipFile(applicationPath, guidFile.FullName, guidUnzipped);
+                    using (var reader = new StreamReader(guidUnzipped))
                     {
                         var applicationGuid = reader.ReadToEnd();
                         if (applicationGuid != guid)
@@ -50,14 +54,17 @@ namespace Unity.BuildReportInspector.Mobile
                         }
                     }
                 }
-                
+
                 GenerateMobileAppendix(applicationPath, guid);
             }
             catch
             {
                 Debug.LogError("Could not open the application archive. Please provide a valid .ipa bundle.");
             }
-
+            finally
+            {
+                Directory.Delete(temporaryFolder, true);
+            }
         }
 
         private static void GenerateMobileAppendix(string applicationPath, string guid)

--- a/com.unity.build-report-inspector/Editor/Mobile/Utilities.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/Utilities.cs
@@ -7,6 +7,7 @@ namespace Unity.BuildReportInspector.Mobile
 {
     internal static class Utilities
     {
+        private const string k_Unzip = "/usr/bin/unzip";
         public static bool IsTestEnvironment => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BOKKEN_RESOURCEID"));
 
         internal static string RunProcessAndGetOutput(string executable, string arguments, out int exitCode)
@@ -39,6 +40,43 @@ namespace Unity.BuildReportInspector.Mobile
         internal static string Combine(params string[] parts)
         {
             return parts.Aggregate(string.Empty, Path.Combine);
+        }
+        
+        /// <summary>
+        /// Unzip a file from a zip archive (macOS only).
+        /// </summary>
+        internal static void UnzipFile(string archivePath, string fileName, string destination)
+        {
+            using (var p = new Process())
+            {
+                p.StartInfo.FileName = k_Unzip;
+                p.StartInfo.Arguments = $"-p \"{archivePath}\" \"{fileName}\"";
+                p.StartInfo.UseShellExecute = false;
+                p.StartInfo.CreateNoWindow = true;
+                p.StartInfo.RedirectStandardOutput = true;
+                p.StartInfo.RedirectStandardError = true;
+                p.Start();
+                var baseStream = p.StandardOutput.BaseStream as FileStream;
+                byte[] fileBytes;
+                using (var memoryStream = new MemoryStream())
+                {
+                    var buffer = new byte[65536];
+                    int lastRead;
+                    do
+                    {
+                        lastRead = baseStream.Read(buffer, 0, buffer.Length);
+                        memoryStream.Write(buffer, 0, lastRead);
+                    } while (lastRead > 0);
+
+                    fileBytes = memoryStream.ToArray();
+                }
+
+                using (var fileStream = new FileStream(destination, FileMode.Create))
+                {
+                    fileStream.Write(fileBytes, 0, fileBytes.Length);
+                }
+                p.WaitForExit();
+            }
         }
     }
 }

--- a/com.unity.build-report-inspector/Editor/Mobile/Utilities.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/Utilities.cs
@@ -7,7 +7,6 @@ namespace Unity.BuildReportInspector.Mobile
 {
     internal static class Utilities
     {
-        private const string k_Unzip = "/usr/bin/unzip";
         public static bool IsTestEnvironment => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BOKKEN_RESOURCEID"));
 
         internal static string RunProcessAndGetOutput(string executable, string arguments, out int exitCode)
@@ -40,43 +39,6 @@ namespace Unity.BuildReportInspector.Mobile
         internal static string Combine(params string[] parts)
         {
             return parts.Aggregate(string.Empty, Path.Combine);
-        }
-        
-        /// <summary>
-        /// Unzip a file from a zip archive (macOS only).
-        /// </summary>
-        internal static void UnzipFile(string archivePath, string fileName, string destination)
-        {
-            using (var p = new Process())
-            {
-                p.StartInfo.FileName = k_Unzip;
-                p.StartInfo.Arguments = $"-p \"{archivePath}\" \"{fileName}\"";
-                p.StartInfo.UseShellExecute = false;
-                p.StartInfo.CreateNoWindow = true;
-                p.StartInfo.RedirectStandardOutput = true;
-                p.StartInfo.RedirectStandardError = true;
-                p.Start();
-                var baseStream = p.StandardOutput.BaseStream as FileStream;
-                byte[] fileBytes;
-                using (var memoryStream = new MemoryStream())
-                {
-                    var buffer = new byte[65536];
-                    int lastRead;
-                    do
-                    {
-                        lastRead = baseStream.Read(buffer, 0, buffer.Length);
-                        memoryStream.Write(buffer, 0, lastRead);
-                    } while (lastRead > 0);
-
-                    fileBytes = memoryStream.ToArray();
-                }
-
-                using (var fileStream = new FileStream(destination, FileMode.Create))
-                {
-                    fileStream.Write(fileBytes, 0, fileBytes.Length);
-                }
-                p.WaitForExit();
-            }
         }
     }
 }

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility.meta
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility.meta
@@ -1,5 +1,6 @@
 fileFormatVersion: 2
-guid: 284792f4e3f9e461b9817911378bbe87
+guid: 8758917d5bd004e4c9b1dfb16cf52a3a
+folderAsset: yes
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System;
+
+namespace Unity.BuildReportInspector.Mobile.ZipUtility
+{
+    internal enum Markers
+    {
+        EntryCount = 10,
+        CentralDirectoryRecord = 16,
+        CompressedSize = 20,
+        UncompressedSize = 24,
+        NameLength = 28,
+        ExtraLength = 30,
+        CommentLength = 32,
+        Name = 46
+    }
+
+    public class ZipBundle : IDisposable
+    {
+        public string FullName { get; }
+        public long Length { get; }
+        public List<ZipEntry> Entries { get; }
+
+        private const int k_EndOfCentralDirectoryMarker = 101010256;
+        private readonly FileStream m_ZipStream;
+        private long m_EndOfCentralDirectoryOffset;
+        private long EndOfCentralDirectoryOffset
+        {
+            get
+            {
+                if (m_EndOfCentralDirectoryOffset == 0)
+                    m_EndOfCentralDirectoryOffset = FindEndOfCentralDirectoryOffset();
+                return m_EndOfCentralDirectoryOffset;
+            }
+        }
+
+        private long FindEndOfCentralDirectoryOffset()
+        {
+            var marker = BitConverter.GetBytes(k_EndOfCentralDirectoryMarker);
+            for (var offset = 4; offset <= m_ZipStream.Length; offset++)
+            {
+                m_ZipStream.Seek(-offset, SeekOrigin.End);
+                var sizeBytes = new byte[4];
+                m_ZipStream.Read(sizeBytes, 0, 4);
+                if (!sizeBytes.SequenceEqual(marker))
+                    continue;
+                m_ZipStream.Seek(-4, SeekOrigin.Current);
+                return m_ZipStream.Position;
+            }
+
+            throw new Exception("Archive invalid - could not find end-of-central-directory marker.");
+        }
+
+        private int GetArchiveEntryCount()
+        {
+            return ReadUShort(EndOfCentralDirectoryOffset + (int)Markers.EntryCount);
+        }
+
+        private long GetCentralDirectoryOffset()
+        {
+            return ReadUInt(EndOfCentralDirectoryOffset + (int)Markers.CentralDirectoryRecord);
+        }
+
+        private byte[] GetBytes(long position, int length)
+        {
+            m_ZipStream.Seek(position, SeekOrigin.Begin);
+            var resultBytes = new byte[length];
+            m_ZipStream.Read(resultBytes, 0, length);
+            return resultBytes;
+        }
+
+        private ushort ReadUShort(long position)
+        {
+            return BitConverter.ToUInt16(GetBytes(position, 2), 0);
+        }
+
+        private uint ReadUInt(long position)
+        {
+            return BitConverter.ToUInt32(GetBytes(position, 4), 0);
+        }
+
+        private string ReadString(long position, int length)
+        {
+            return System.Text.Encoding.Default.GetString(GetBytes(position, length));
+        }
+
+        private void ValidateZip()
+        {
+            FindEndOfCentralDirectoryOffset();
+        }
+
+        public ZipBundle(string path)
+        {
+            m_ZipStream = File.Open(path, FileMode.Open);
+
+            ValidateZip();
+
+            FullName = path;
+            Length = new FileInfo(path).Length;
+
+            var entryCount = GetArchiveEntryCount();
+            var recordStart = GetCentralDirectoryOffset();
+            Entries = new List<ZipEntry>();
+            for (var _ = 0; _ < entryCount; _++)
+            {
+                var compressedSize = ReadUInt(recordStart + (int)Markers.CompressedSize);
+                var uncompressedSize = ReadUInt(recordStart + (int)Markers.UncompressedSize);
+                var nameLength = ReadUShort(recordStart + (int)Markers.NameLength);
+                var extraLength = ReadUInt(recordStart + (int)Markers.ExtraLength);
+                var commentLength = ReadUShort(recordStart + (int)Markers.CommentLength);
+                var name = ReadString(recordStart + (int)Markers.Name, nameLength);
+                Entries.Add(new ZipEntry(name, compressedSize, uncompressedSize));
+                recordStart = recordStart + (int) Markers.Name + nameLength + extraLength + commentLength;
+            }
+        }
+
+        public override string ToString()
+        {
+            return FullName;
+        }
+
+        public void Dispose()
+        {
+            m_ZipStream.Close();
+        }
+    }
+}

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
@@ -108,7 +108,7 @@ namespace Unity.BuildReportInspector.Mobile.ZipUtility
                 var compressedSize = ReadUInt(recordStart + (int)Markers.CompressedSize);
                 var uncompressedSize = ReadUInt(recordStart + (int)Markers.UncompressedSize);
                 var nameLength = ReadUShort(recordStart + (int)Markers.NameLength);
-                var extraLength = ReadUInt(recordStart + (int)Markers.ExtraLength);
+                var extraLength = ReadUShort(recordStart + (int)Markers.ExtraLength);
                 var commentLength = ReadUShort(recordStart + (int)Markers.CommentLength);
                 var name = ReadString(recordStart + (int)Markers.Name, nameLength);
                 Entries.Add(new ZipEntry(name, compressedSize, uncompressedSize));

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
@@ -17,7 +17,7 @@ namespace Unity.BuildReportInspector.Mobile.ZipUtility
         Name = 46
     }
 
-    public class ZipBundle : IDisposable
+    internal class ZipBundle : IDisposable
     {
         public string FullName { get; }
         public long Length { get; }

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs
@@ -24,6 +24,7 @@ namespace Unity.BuildReportInspector.Mobile.ZipUtility
         public List<ZipEntry> Entries { get; }
 
         private const int k_EndOfCentralDirectoryMarker = 101010256;
+        private const int k_MaxEndOfCentralDirectoryOffset = 65557;
         private readonly FileStream m_ZipStream;
         private long m_EndOfCentralDirectoryOffset;
         private long EndOfCentralDirectoryOffset
@@ -39,7 +40,7 @@ namespace Unity.BuildReportInspector.Mobile.ZipUtility
         private long FindEndOfCentralDirectoryOffset()
         {
             var marker = BitConverter.GetBytes(k_EndOfCentralDirectoryMarker);
-            for (var offset = 4; offset <= m_ZipStream.Length; offset++)
+            for (var offset = 4; offset <= k_MaxEndOfCentralDirectoryOffset; offset++)
             {
                 m_ZipStream.Seek(-offset, SeekOrigin.End);
                 var sizeBytes = new byte[4];

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs.meta
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipBundle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f716688a82d7040f183e2f3529e1ac35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipEntry.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipEntry.cs
@@ -1,0 +1,25 @@
+using System.IO;
+
+namespace Unity.BuildReportInspector.Mobile.ZipUtility
+{
+    public class ZipEntry
+    {
+        public string Name { get; }
+        public string FullName { get; }
+        public uint CompressedSize { get; }
+        public uint UncompressedSize { get; }
+
+        internal ZipEntry(string fullName, uint compressedSize, uint uncompressedSize)
+        {
+            Name = Path.GetFileName(fullName);
+            FullName = fullName;
+            CompressedSize = compressedSize;
+            UncompressedSize = uncompressedSize;
+        }
+        
+        public override string ToString()
+        {
+            return FullName;
+        }
+    }
+}

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipEntry.cs
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipEntry.cs
@@ -2,7 +2,7 @@ using System.IO;
 
 namespace Unity.BuildReportInspector.Mobile.ZipUtility
 {
-    public class ZipEntry
+    internal class ZipEntry
     {
         public string Name { get; }
         public string FullName { get; }

--- a/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipEntry.cs.meta
+++ b/com.unity.build-report-inspector/Editor/Mobile/ZipUtility/ZipEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd4041f62bb344d70a53714b5b78396e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.build-report-inspector/Editor/Mobile/csc.rsp
+++ b/com.unity.build-report-inspector/Editor/Mobile/csc.rsp
@@ -1,2 +1,0 @@
--r:System.IO.Compression.FileSystem.dll
--r:System.IO.Compression.dll

--- a/com.unity.build-report-inspector/Editor/csc.rsp
+++ b/com.unity.build-report-inspector/Editor/csc.rsp
@@ -1,2 +1,0 @@
--r:System.IO.Compression.FileSystem.dll
--r:System.IO.Compression.dll

--- a/com.unity.build-report-inspector/Editor/csc.rsp.meta
+++ b/com.unity.build-report-inspector/Editor/csc.rsp.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 645c8c93230fe43ad8ec35be0110b31c
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/com.unity.build-report-inspector/README.md
+++ b/com.unity.build-report-inspector/README.md
@@ -8,7 +8,9 @@ This script allows you to inspect this information graphically in the Editor UI,
 Disclaimer
 ==========
 
-This package gets the information it can from the BuildReport Scripting API (https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildReport.html).
+This package is provided as-is, with no support from Unity Technologies. We plan to add a built-in and supported UI for the BuildReport feature in a future version of Unity, but until then, this package serves as a demonstration on how you can access the BuildReport information today.
+
+In particular, this package gets the information it can from the BuildReport Scripting API (https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildReport.html).  
 
 Usage
 =====

--- a/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
+++ b/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
@@ -35,10 +35,6 @@ public class AndroidTests
         var appendix = BuildPlayer(ScriptingImplementation.IL2CPP, AndroidArchitecture.All, true);
 
         Assert.AreEqual(2, appendix.Architectures.Length, "Appendix contains unexpected architectures.");
-        foreach (var arch in appendix.Architectures)
-        {
-            Debug.Log(arch.Name);
-        }
         Assert.That(appendix.Architectures.Any(x => x.Name == "armeabi-v7a"), "Architecture armeabi-v7a not found in the appendix.");
         Assert.That(appendix.Architectures.Any(x => x.Name == "arm64-v8a"), "Architecture arm64-v8a not found in the appendix.");
 

--- a/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
+++ b/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -12,6 +13,7 @@ using UnityEngine;
 public class AndroidTests
 {
     private string m_BuildPath;
+    private List<string> m_AppendixGuids;
 
     [Test]
     public void Android_CanGenerateApkAppendix()
@@ -62,6 +64,16 @@ public class AndroidTests
         {
             Directory.Delete(m_BuildPath, true);
         }
+
+        if (m_AppendixGuids == null) return;
+        foreach (var guid in m_AppendixGuids)
+        {
+            var appendixPath = Path.Combine(MobileHelper.AppendixSavePath, guid);
+            var appendixMeta = $"{appendixPath}.meta";
+            Debug.Log(appendixPath);
+            File.Delete(appendixPath);
+            File.Delete(appendixMeta);
+        }
     }
 
     private MobileAppendix BuildPlayer(ScriptingImplementation backend, AndroidArchitecture architecture, bool buildAab)
@@ -77,6 +89,10 @@ public class AndroidTests
         };
 
         var report = BuildPipeline.BuildPlayer(options);
-        return MobileHelper.LoadMobileAppendix(report.summary.guid.ToString());
+        if (m_AppendixGuids == null)
+            m_AppendixGuids = new List<string>();
+        var appendixGuid = report.summary.guid.ToString();
+        m_AppendixGuids.Add(appendixGuid);
+        return MobileHelper.LoadMobileAppendix(appendixGuid);
     }
 }

--- a/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
+++ b/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
@@ -69,10 +69,8 @@ public class AndroidTests
         foreach (var guid in m_AppendixGuids)
         {
             var appendixPath = Path.Combine(MobileHelper.AppendixSavePath, guid);
-            var appendixMeta = $"{appendixPath}.meta";
-            Debug.Log(appendixPath);
             File.Delete(appendixPath);
-            File.Delete(appendixMeta);
+            File.Delete($"{appendixPath}.meta");
         }
     }
 

--- a/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
+++ b/com.unity.build-report-inspector/Tests/Editor/Mobile/AndroidTests.cs
@@ -14,6 +14,9 @@ public class AndroidTests
 {
     private string m_BuildPath;
     private List<string> m_AppendixGuids;
+    private bool m_DeleteAppendixFolder;
+    private bool m_DeleteReportFolder;
+    private string m_ReportPath;
 
     [Test]
     public void Android_CanGenerateApkAppendix()
@@ -55,6 +58,9 @@ public class AndroidTests
     public void Setup()
     {
         m_BuildPath = Utilities.GetTemporaryFolder();
+        m_DeleteAppendixFolder = !Directory.Exists(MobileHelper.AppendixSavePath);
+        m_ReportPath = new DirectoryInfo(MobileHelper.AppendixSavePath).Parent?.FullName;
+        m_DeleteReportFolder = !Directory.Exists(m_ReportPath);
     }
 
     [OneTimeTearDown]
@@ -65,7 +71,23 @@ public class AndroidTests
             Directory.Delete(m_BuildPath, true);
         }
 
-        if (m_AppendixGuids == null) return;
+        if (m_DeleteReportFolder)
+        {
+            Directory.Delete(m_ReportPath, true);
+            File.Delete($"{m_ReportPath}.meta");
+            return;
+        }
+
+        if (m_DeleteAppendixFolder)
+        {
+            Directory.Delete(MobileHelper.AppendixSavePath);
+            File.Delete($"{MobileHelper.AppendixSavePath}.meta");
+            return;
+        }
+
+        if (m_AppendixGuids == null)
+            return;
+
         foreach (var guid in m_AppendixGuids)
         {
             var appendixPath = Path.Combine(MobileHelper.AppendixSavePath, guid);


### PR DESCRIPTION
Changes:
Omit the need for csc.rsp files by replacing C# compression libraries.
Refactor Android tests.
Fix legal support disclaimer.