### PR TITLE
Support for sorting on the OutputFiles tab.

### DIFF
--- a/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
+++ b/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
@@ -497,7 +497,7 @@ namespace Unity.BuildReportInspector
             
             foreach (BuildFile file in files)
             {
-                if (string.Compare(file.role, roleFilter, StringComparison.OrdinalIgnoreCase) != 0) {
+                if (roleFilter != null && string.Compare(file.role, roleFilter, StringComparison.OrdinalIgnoreCase) != 0) {
                     continue;
                 }
                 
@@ -709,24 +709,13 @@ namespace Unity.BuildReportInspector
             }
 
             BuildFile[] reportFiles = report.files;
+            float vPos = -scrollPosition.y;
             var odd = false;
             
             switch (outputDispMode) {
                 case OutputFilesDisplayMode.Size:
                     Array.Sort(reportFiles, (fileA, fileB) => { return fileB.size.CompareTo(fileA.size); });
-
-                    foreach (var file in reportFiles)
-                    {
-                        if (file.path.StartsWith(tempRoot))
-                            continue;
-                        
-                        GUILayout.BeginHorizontal(odd? OddStyle:EvenStyle);
-                        odd = !odd;
-                        GUILayout.Label(new GUIContent(file.path.Substring(longestCommonRoot.Length), file.path), GUILayout.MaxWidth(EditorGUIUtility.currentViewWidth - 260));
-                        GUILayout.Label(file.role);
-                        GUILayout.Label(FormatSize(file.size), SizeStyle);
-                        GUILayout.EndHorizontal();
-                    }
+                    ShowOutputFiles(reportFiles, ref vPos, longestCommonRoot.Length);
                     break;
                 case OutputFilesDisplayMode.Role:
                     Array.Sort(reportFiles, (fileA, fileB) => {
@@ -734,7 +723,6 @@ namespace Unity.BuildReportInspector
                         return comparison == 0 ? fileB.size.CompareTo(fileA.size) : comparison; 
                     });
 
-                    float vPos = -scrollPosition.y;
                     Dictionary<string, ulong> sizePerRole = new Dictionary<string, ulong>();
                     
                     foreach (BuildFile file in reportFiles) {

--- a/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
+++ b/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
@@ -148,8 +148,15 @@ namespace Unity.BuildReportInspector
             ImporterType
         };
 
+        private enum OutputFilesDisplayMode
+        {
+            Size,
+            FileType
+        };
+
         ReportDisplayMode mode;
         SourceAssetsDisplayMode sourceDispMode;
+        OutputFilesDisplayMode outputDispMode;
 
         private Vector2 scrollPosition;
 
@@ -191,7 +198,12 @@ namespace Unity.BuildReportInspector
             if (mode == ReportDisplayMode.SourceAssets)
             {
                 sourceDispMode = (SourceAssetsDisplayMode)EditorGUILayout.EnumPopup("Sort by:", sourceDispMode);
+            } 
+            else if (mode == ReportDisplayMode.OutputFiles)
+            {
+                outputDispMode = (OutputFilesDisplayMode)EditorGUILayout.EnumPopup("Sort by:", outputDispMode);
             }
+            
 #if UNITY_2019_3_OR_NEWER
             if (mode == ReportDisplayMode.OutputFiles && mobileAppendix != null)
             {
@@ -665,19 +677,30 @@ namespace Unity.BuildReportInspector
                     break;
                 }
             }
-            var odd = false;
-            foreach (var file in report.files)
-            {
-                if (file.path.StartsWith(tempRoot))
-                    continue;
-                GUILayout.BeginHorizontal(odd? OddStyle:EvenStyle);
-                odd = !odd;
-                GUILayout.Label(new GUIContent(file.path.Substring(longestCommonRoot.Length), file.path), GUILayout.MaxWidth(EditorGUIUtility.currentViewWidth - 260));
-                GUILayout.Label(file.role);
-                GUILayout.Label(FormatSize(file.size), SizeStyle);
-                GUILayout.EndHorizontal();
 
+            switch (outputDispMode) {
+                case OutputFilesDisplayMode.Size:
+                    var odd = false;
+
+                    BuildFile[] reportFiles = report.files;
+                    Array.Sort(reportFiles, (fileA, fileB) => { return fileB.size.CompareTo(fileA.size); });
+                        
+                    foreach (var file in reportFiles)
+                    {
+                        if (file.path.StartsWith(tempRoot))
+                            continue;
+                        GUILayout.BeginHorizontal(odd? OddStyle:EvenStyle);
+                        odd = !odd;
+                        GUILayout.Label(new GUIContent(file.path.Substring(longestCommonRoot.Length), file.path), GUILayout.MaxWidth(EditorGUIUtility.currentViewWidth - 260));
+                        GUILayout.Label(file.role);
+                        GUILayout.Label(FormatSize(file.size), SizeStyle);
+                        GUILayout.EndHorizontal();
+                    }
+                    break;
+                case OutputFilesDisplayMode.FileType:
+                    break;
             }
+
         }
 
 #if UNITY_2019_3_OR_NEWER

--- a/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
+++ b/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
@@ -518,7 +518,8 @@ namespace Unity.BuildReportInspector
                 }
                 
                 GUILayout.BeginHorizontal(odd ? OddStyle : EvenStyle);
-                GUILayout.Label(new GUIContent(file.path.Substring(rootLength), file.path));
+                GUIContent guiContent = new GUIContent(file.path.Substring(rootLength), file.path); 
+                GUILayout.Label(guiContent, GUILayout.MaxWidth(EditorGUIUtility.currentViewWidth - 260));
                 
                 if (string.IsNullOrEmpty(roleFilter)) 
                 {


### PR DESCRIPTION
Hey!

I needed support for sorting on the Output Files tab, so I went ahead and implemented it. 

I was only now noticing the contributing guidelines, which state: "Talk to us before doing the work -- we love contributions, but we might already be working on the same thing, or we might have different opinions on how it should be implemented."

I'm too late to speak to you first, but maybe we can speak now?

In summary, this code does the following:
- Adds support for sorting by file size and role on non-mobile builds, on the Output Files tab.
- Adds support for sorting by compressed and uncompressed file size on mobile builds, on the Output Files tab.

I'll be happy to make any changes deemed necessary if you feel as though this contribution could be useful.

Below you can see some screenshots of this in action, within the Test Project you provided:

![Screenshot 2022-05-08 at 16 59 18](https://user-images.githubusercontent.com/2806093/167306369-e25c928d-3404-4b39-bcd2-8a2e158aedc5.png)
![Screenshot 2022-05-08 at 16 59 09](https://user-images.githubusercontent.com/2806093/167306370-09d91c5e-3ff5-4c18-9fb0-1710df7d4613.png)
![Screenshot 2022-05-08 at 16 56 02](https://user-images.githubusercontent.com/2806093/167306371-6bbae0ed-256f-418c-b829-b738a1e26783.png)

