### PR TITLE
Optimized the project build size

### DIFF
--- a/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
+++ b/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
@@ -26,7 +26,7 @@ namespace Unity.BuildReportInspector
         [MenuItem("Window/Open Last Build Report")]
         public static void OpenLastBuild()
         {
-            const string buildReportDir = "Assets/BuildReports";
+            const string buildReportDir = "Assets/Editor/BuildReports";
             if (!Directory.Exists(buildReportDir))
                 Directory.CreateDirectory(buildReportDir);
 


### PR DESCRIPTION
Optimized the project build size by nesting the BuildReports folder in the special Editor folder which is ignored when the project is built thus preventing the build reports from being included in builds.