### PR TITLE
Excluded build reports from exports

### DIFF
--- a/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
+++ b/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
@@ -26,7 +26,7 @@ namespace Unity.BuildReportInspector
         [MenuItem("Window/Open Last Build Report")]
         public static void OpenLastBuild()
         {
-            const string buildReportDir = "Assets/BuildReports";
+            const string buildReportDir = "Assets/Editor/BuildReports";
             if (!Directory.Exists(buildReportDir))
                 Directory.CreateDirectory(buildReportDir);
 


### PR DESCRIPTION
Excluded build reports from exports by changing the storage directory from "Assets/BuildReports" to "Assets/Editor/BuildReports".

Fixes: #33