### PR TITLE
Fixed the object name warning

### DIFF
--- a/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
+++ b/com.unity.build-report-inspector/Editor/BuildReportInspector.cs
@@ -30,11 +30,13 @@ namespace Unity.BuildReportInspector
             if (!Directory.Exists(buildReportDir))
                 Directory.CreateDirectory(buildReportDir);
 
+            var path = buildReportDir + "/New Report.buildreport";
             var date = File.GetLastWriteTime("Library/LastBuild.buildreport");
-            var assetPath = buildReportDir + "/Build_" + date.ToString("yyyy-dd-MMM-HH-mm-ss") + ".buildreport";
-            File.Copy("Library/LastBuild.buildreport", assetPath, true);
-            AssetDatabase.ImportAsset(assetPath);
-            Selection.objects = new Object[] { AssetDatabase.LoadAssetAtPath<BuildReport>(assetPath) };
+            var name = "Build_" + date.ToString("yyyy-dd-MMM-HH-mm-ss") + ".buildreport";
+            File.Copy("Library/LastBuild.buildreport", path, true);
+            AssetDatabase.ImportAsset(path);
+            AssetDatabase.RenameAsset(path, name);
+            Selection.objects = new Object[] { AssetDatabase.LoadAssetAtPath<BuildReport>(buildReportDir + "/" + name) };
         }
 
         private BuildReport report


### PR DESCRIPTION
Fixed the object name warning by editing the code responsible for opening the last build report to first copy "Library/LastBuild.buildreport" to the build report storage directory with a file name of "New Report.buildreport" then importing it before applying a more meaningful name and finally loading it causing the warning to no longer appear.

Fixes: #34