### PR TITLE
Excluded build reports from Git

### DIFF
--- a/com.unity.build-report-inspector/Editor/Assets.meta
+++ b/com.unity.build-report-inspector/Editor/Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6742a7fa087ba7a529774c14111d8e8f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.build-report-inspector/Editor/Assets/BuildReports.meta
+++ b/com.unity.build-report-inspector/Editor/Assets/BuildReports.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b417c6b244080c11da8223d9d0200fe5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.build-report-inspector/Editor/Assets/BuildReports/.gitignore
+++ b/com.unity.build-report-inspector/Editor/Assets/BuildReports/.gitignore
@@ -1,0 +1,2 @@
+*.buildreport
+*.buildreport.meta

--- a/com.unity.build-report-inspector/Editor/Bootstrapper.cs
+++ b/com.unity.build-report-inspector/Editor/Bootstrapper.cs
@@ -1,0 +1,26 @@
+using UnityEditor;
+using System.IO;
+
+namespace Unity.BuildReportInspector
+{
+    [InitializeOnLoad]
+    public class Bootstrapper
+    {
+        private const string SourcePath = "Packages/com.unity.build-report-inspector/Editor/Assets/BuildReports/.gitignore";
+        private const string TargetDirectory = "Assets/BuildReports";
+        private const string TargetFileName = ".gitignore";
+
+        static Bootstrapper()
+        {
+            if (!Directory.Exists(TargetDirectory))
+            {
+                Directory.CreateDirectory(TargetDirectory);
+            }
+
+            if (!System.IO.File.Exists(TargetDirectory + "/" + TargetFileName))
+            {
+                System.IO.File.Copy(SourcePath, TargetDirectory + "/" + TargetFileName, true);
+            }
+        }
+    }
+}

--- a/com.unity.build-report-inspector/Editor/Bootstrapper.cs.meta
+++ b/com.unity.build-report-inspector/Editor/Bootstrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b6ce561e96a983028390ff0bd81ec1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Excluded build reports from Git by default by creating a bootstrapper script that initialises on load and copies a .gitignore to the build report storage directory that configures Git to ignore build report files.

Fixes: #35