### PR TITLE
Adding Sanitization to Path on Source Assets Generation

### DIFF
--- a/com.unity.build-report-inspector/Editor/SourceAssets.cs
+++ b/com.unity.build-report-inspector/Editor/SourceAssets.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
+using System.Text.RegularExpressions;
 
 namespace Unity.BuildReportInspector
 {
@@ -101,6 +102,10 @@ namespace Unity.BuildReportInspector
                         if (string.IsNullOrEmpty(path))
                             path = "Generated"; // Build output not associated with a source asset
 
+                        string regexSearch = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
+                        Regex regex = new Regex(string.Format("[{0}]", Regex.Escape(regexSearch)));
+                        string sanitizedPath = regex.Replace(path, "");
+
                         assetTypesInFile[key] = new ContentEntry
                         {
                             size = entry.packedSize,
@@ -109,7 +114,7 @@ namespace Unity.BuildReportInspector
                             internalArchivePath = internalArchivePath,
                             type = type,
                             path = path,
-                            extension = Path.GetExtension(path),
+                            extension = Path.GetExtension(sanitizedPath),
                             objectCount = 1
                         };
                     }


### PR DESCRIPTION
Adding Regex sanitization on the Path of the source assets to avoid a possible error for invalid characters of the name of certain assets.

Used to solve an Exception that can be caused by some assets (ArgumentException: Illegal characters in path). Tested with assets names like: "Built-in Texture2D: sactx-0-1024x512-DXT5|BC3-_mainmenu-936da5f0" that were causing that exception before, making it impossible to generate the report for all the other assets.